### PR TITLE
Laravel updated up to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 ### Changed
 
 - Maximal `illuminate/*` packages version now is `7.*`
+- Minimal required PHP version now is `7.2`
 - Classes `RequestsStack` and `ResponsesStack` do not extend `Illuminate\Support\Collection`
 - Interfaces `RequestsStackInterface` and `ResponsesStackInterface` do not extend `Illuminate\Contracts\Support\Arrayable`
 - Method `push()` in `RequestsStack` and `ResponsesStack` return `void` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v2.0.0
+
+### Changed
+
+- Classes `RequestsStack` and `ResponsesStack` does not extends `Illuminate\Support\Collection`
+- Method `push()` in `RequestsStack` and `ResponsesStack` return `void` now
+
+
 ## v1.2.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,15 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- Classes `RequestsStack` and `ResponsesStack` does not extends `Illuminate\Support\Collection`
+- Maximal `illuminate/*` packages version now is `7.*`
+- Classes `RequestsStack` and `ResponsesStack` do not extend `Illuminate\Support\Collection`
+- Interfaces `RequestsStackInterface` and `ResponsesStackInterface` do not extend `Illuminate\Contracts\Support\Arrayable`
 - Method `push()` in `RequestsStack` and `ResponsesStack` return `void` now
 
+### Added
+
+- Methods `all()`, `getIterator()`, `count()`, `isEmpty()`, `isNotEmpty()` and `first()` implementation in `RequestsStack` and `ResponsesStack` classes
+- Type-hints for methods in `RequestsStackInterface` and `ResponsesStackInterface` interfaces
 
 ## v1.2.0
 

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,16 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
-        "illuminate/contracts": "^5.5 || ~6.0",
-        "illuminate/support": "^5.5 || ~6.0",
-        "illuminate/http": "^5.5 || ~6.0",
-        "illuminate/routing": "^5.5 || ~6.0",
+        "php": "^7.2",
+        "illuminate/contracts": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/support": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/http": "^5.5 || ~6.0 || ~7.0",
+        "illuminate/routing": "^5.5 || ~6.0 || ~7.0",
         "tarampampam/wrappers-php": "^1.4"
     },
     "require-dev": {
-        "laravel/laravel": "^5.5 || ~6.0",
-        "phpunit/phpunit": "~7.5",
+        "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
+        "phpunit/phpunit": "^6.4 || ~7.5",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "laravel/laravel": "^5.5 || ~6.0 || ~7.0",
-        "phpunit/phpunit": "^6.4 || ~7.5",
+        "phpunit/phpunit": "~7.5",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^0.12"
     },

--- a/src/Requests/RequestsStackInterface.php
+++ b/src/Requests/RequestsStackInterface.php
@@ -5,23 +5,20 @@ namespace AvtoDev\JsonRpc\Requests;
 use Countable;
 use LogicException;
 use IteratorAggregate;
-use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * @see RequestsStack
+ * @see     RequestsStack
  *
  * @extends IteratorAggregate<ErroredRequestInterface|RequestInterface>
  */
-interface RequestsStackInterface extends Countable, Arrayable, IteratorAggregate
+interface RequestsStackInterface extends Countable, IteratorAggregate
 {
     /**
      * Push request into stack.
      *
      * @param ErroredRequestInterface|RequestInterface $request
-     *
-     * @return mixed
      */
-    public function push($request);
+    public function push($request): void;
 
     /**
      * @throws LogicException
@@ -33,7 +30,7 @@ interface RequestsStackInterface extends Countable, Arrayable, IteratorAggregate
     /**
      * @return array<mixed>
      */
-    public function all();
+    public function all(): array;
 
     /**
      * Is batch response?

--- a/src/Responses/ResponsesStackInterface.php
+++ b/src/Responses/ResponsesStackInterface.php
@@ -5,35 +5,32 @@ namespace AvtoDev\JsonRpc\Responses;
 use Countable;
 use LogicException;
 use IteratorAggregate;
-use Illuminate\Contracts\Support\Arrayable;
 
 /**
- * @see ResponsesStack
+ * @see     ResponsesStack
  *
  * @extends IteratorAggregate<ResponseInterface>
  */
-interface ResponsesStackInterface extends Countable, Arrayable, IteratorAggregate
+interface ResponsesStackInterface extends Countable, IteratorAggregate
 {
     /**
      * Push response into stack.
      *
      * @param ResponseInterface $response
-     *
-     * @return ResponsesStackInterface<ResponseInterface>
      */
-    public function push($response);
+    public function push($response): void;
 
     /**
      * @throws LogicException
      *
      * @return ResponseInterface
      */
-    public function first();
+    public function first(): ResponseInterface;
 
     /**
      * @return array<ResponseInterface>
      */
-    public function all();
+    public function all(): array;
 
     /**
      * Is batch response?
@@ -43,9 +40,16 @@ interface ResponsesStackInterface extends Countable, Arrayable, IteratorAggregat
     public function isBatch(): bool;
 
     /**
+     * Determine if stack is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty(): bool;
+
+    /**
      * Determine if stack is not empty.
      *
      * @return bool
      */
-    public function isNotEmpty();
+    public function isNotEmpty(): bool;
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,13 +12,6 @@ use AvtoDev\JsonRpc\Factories\FactoryInterface;
 class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Register RPC services.
      *
      * @return void

--- a/tests/Errors/InternalErrorTest.php
+++ b/tests/Errors/InternalErrorTest.php
@@ -16,7 +16,8 @@ class InternalErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Internal error', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Internal error', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(InternalError::class, $error);
     }
 
     /**

--- a/tests/Errors/InvalidParamsErrorTest.php
+++ b/tests/Errors/InvalidParamsErrorTest.php
@@ -16,7 +16,8 @@ class InvalidParamsErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Invalid params', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Invalid params', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(InvalidParamsError::class, $error);
     }
 
     /**

--- a/tests/Errors/InvalidRequestErrorTest.php
+++ b/tests/Errors/InvalidRequestErrorTest.php
@@ -16,7 +16,8 @@ class InvalidRequestErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Invalid Request', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Invalid Request', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(InvalidRequestError::class, $error);
     }
 
     /**

--- a/tests/Errors/MethodNotFoundErrorTest.php
+++ b/tests/Errors/MethodNotFoundErrorTest.php
@@ -16,7 +16,8 @@ class MethodNotFoundErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Method not found', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Method not found', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(MethodNotFoundError::class, $error);
     }
 
     /**

--- a/tests/Errors/ParseErrorTest.php
+++ b/tests/Errors/ParseErrorTest.php
@@ -16,7 +16,8 @@ class ParseErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Parse error', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Parse error', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(ParseError::class, $error);
     }
 
     /**

--- a/tests/Errors/ServerErrorTest.php
+++ b/tests/Errors/ServerErrorTest.php
@@ -16,7 +16,8 @@ class ServerErrorTest extends AbstractErrorTestCase
      */
     public function testDefaultMessage(): void
     {
-        $this->assertSame('Server Error', $this->errorFactory(null)->getMessage());
+        $this->assertSame('Server Error', ($error = $this->errorFactory(null))->getMessage());
+        $this->assertInstanceOf(ServerError::class, $error);
     }
 
     /**

--- a/tests/Factories/RequestFactoryTest.php
+++ b/tests/Factories/RequestFactoryTest.php
@@ -120,8 +120,8 @@ class RequestFactoryTest extends AbstractTestCase
         $this->assertSame(HttpResponse::HTTP_OK, $response->getStatusCode());
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
 
-        $this->assertInternalType('string', $response->getContent(), '');
-        $this->assertEmpty($response->getContent(), '');
+        $this->assertSame('', $response->getContent());
+        $this->assertEmpty($response->getContent());
     }
 
     /**

--- a/tests/Http/Controllers/RpcControllerTest.php
+++ b/tests/Http/Controllers/RpcControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace AvtoDev\JsonRpc\Tests\Http\Controllers;
 
@@ -11,7 +11,6 @@ use Illuminate\Support\Str;
 use AvtoDev\JsonRpc\KernelInterface;
 use AvtoDev\JsonRpc\Router\RouterInterface;
 use AvtoDev\JsonRpc\Tests\AbstractTestCase;
-use Illuminate\Foundation\Testing\TestResponse;
 use AvtoDev\JsonRpc\Http\Controllers\RpcController;
 use Illuminate\Contracts\Routing\Registrar as HttpRegistrar;
 
@@ -146,13 +145,13 @@ class RpcControllerTest extends AbstractTestCase
     }
 
     /**
-     * @param TestResponse $response
-     * @param string       $path
-     * @param              $expect
+     * @param \Illuminate\Foundation\Testing\TestResponse|\Illuminate\Testing\TestResponse $response
+     * @param string                                                                       $path
+     * @param                                                                              $expect
      *
      * @return void
      */
-    private function assertJsonPath(TestResponse $response, string $path, $expect): void
+    private function assertJsonPath($response, string $path, $expect): void
     {
         $this->assertSame($expect, Arr::get($response->decodeResponseJson(), $path));
     }

--- a/tests/Requests/RequestsStackTest.php
+++ b/tests/Requests/RequestsStackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AvtoDev\JsonRpc\Tests\Requests;
 
+use LogicException;
 use Illuminate\Support\Str;
 use AvtoDev\JsonRpc\Requests\Request;
 use AvtoDev\JsonRpc\Requests\RequestsStack;
@@ -64,11 +65,6 @@ class RequestsStackTest extends AbstractTestCase
 
         $this->assertEquals([$value, $value2], $this->instance->all());
         $this->assertCount(2, $this->instance);
-
-        $this->instance->forget([0, 1]);
-
-        $this->assertCount(0, $this->instance);
-        $this->assertEquals([], $this->instance->all());
     }
 
     /**
@@ -97,8 +93,67 @@ class RequestsStackTest extends AbstractTestCase
     }
 
     /**
-     * {@inheritdoc}
-     *
+     * @return void
+     */
+    public function testAll(): void
+    {
+        $this->instance->push($first = new Request(Str::random(), Str::random()));
+        $this->instance->push($second = new Request(Str::random(), Str::random()));
+
+        $this->assertSame([$first, $second], $this->instance->all());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIterator(): void
+    {
+        $this->instance->push($first = new Request(Str::random(), Str::random()));
+        $this->instance->push($second = new Request(Str::random(), Str::random()));
+
+        $iterator = $this->instance->getIterator();
+
+        $this->assertSame($first, $iterator[0]);
+        $this->assertSame($second, $iterator[1]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCount(): void
+    {
+        $this->assertCount(0, $this->instance);
+
+        $this->instance->push($first = new Request(Str::random(), Str::random()));
+        $this->assertCount(1, $this->instance);
+
+        $this->instance->push($second = new Request(Str::random(), Str::random()));
+        $this->assertCount(2, $this->instance);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFirst(): void
+    {
+        $this->instance->push($first = new Request(Str::random(), Str::random()));
+        $this->instance->push($second = new Request(Str::random(), Str::random()));
+
+        $this->assertSame($first, $this->instance->first());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFirstThrownAnExceptionWhenStackInEmpty(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageRegExp('~is empty~');
+
+        $this->instance->first();
+    }
+
+    /**
      * @return RequestsStack
      */
     protected function instanceFactory()

--- a/tests/Responses/ResponsesStackTest.php
+++ b/tests/Responses/ResponsesStackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AvtoDev\JsonRpc\Tests\Responses;
 
+use LogicException;
 use Illuminate\Support\Str;
 use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\Responses\ErrorResponse;
@@ -64,11 +65,6 @@ class ResponsesStackTest extends AbstractTestCase
 
         $this->assertEquals([$value, $value2], $this->instance->all());
         $this->assertCount(2, $this->instance);
-
-        $this->instance->forget([0, 1]);
-
-        $this->assertCount(0, $this->instance);
-        $this->assertEquals([], $this->instance->all());
     }
 
     /**
@@ -94,6 +90,68 @@ class ResponsesStackTest extends AbstractTestCase
     {
         $this->assertTrue((new ResponsesStack(true))->isBatch());
         $this->assertFalse((new ResponsesStack(false))->isBatch());
+    }
+
+
+    /**
+     * @return void
+     */
+    public function testAll(): void
+    {
+        $this->instance->push($first = new SuccessResponse(Str::random(), Str::random()));
+        $this->instance->push($second = new ErrorResponse(Str::random(), new MethodNotFoundError));
+
+        $this->assertSame([$first, $second], $this->instance->all());
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetIterator(): void
+    {
+        $this->instance->push($first = new SuccessResponse(Str::random(), Str::random()));
+        $this->instance->push($second = new ErrorResponse(Str::random(), new MethodNotFoundError));
+
+        $iterator = $this->instance->getIterator();
+
+        $this->assertSame($first, $iterator[0]);
+        $this->assertSame($second, $iterator[1]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCount(): void
+    {
+        $this->assertCount(0, $this->instance);
+
+        $this->instance->push($first = new SuccessResponse(Str::random(), Str::random()));
+        $this->assertCount(1, $this->instance);
+
+        $this->instance->push($second = new ErrorResponse(Str::random(), new MethodNotFoundError));
+        $this->assertCount(2, $this->instance);
+    }
+
+    /**
+     * @return void
+     */
+    public function testFirst(): void
+    {
+        $this->instance->push($first = new SuccessResponse(Str::random(), Str::random()));
+        $this->instance->push($second = new ErrorResponse(Str::random(), new MethodNotFoundError));
+
+        $this->assertSame($first, $this->instance->first());
+    }
+
+    /**
+     * @return void
+     */
+    public function testFirstThrownAnExceptionWhenStackInEmpty(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessageRegExp('~is empty~');
+
+        $this->instance->first();
     }
 
     /**

--- a/tests/Responses/ResponsesStackTest.php
+++ b/tests/Responses/ResponsesStackTest.php
@@ -92,7 +92,6 @@ class ResponsesStackTest extends AbstractTestCase
         $this->assertFalse((new ResponsesStack(false))->isBatch());
     }
 
-
     /**
      * @return void
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | No

## Description

### Changed

- Maximal `illuminate/*` packages version now is `7.*`
- Classes `RequestsStack` and `ResponsesStack` do not extend `Illuminate\Support\Collection`
- Interfaces `RequestsStackInterface` and `ResponsesStackInterface` do not extend `Illuminate\Contracts\Support\Arrayable`
- Method `push()` in `RequestsStack` and `ResponsesStack` return `void` now

### Added

- Methods `all()`, `getIterator()`, `count()`, `isEmpty()`, `isNotEmpty()` and `first()` implementation in `RequestsStack` and `ResponsesStack` classes
- Type-hints for methods in `RequestsStackInterface` and `ResponsesStackInterface` interfaces

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
