### PR TITLE
Laravel 10 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ on:
 jobs: # Docs: <https://git.io/JvxXE>
   php:
     name: PHP ${{ matrix.php }}, ${{ matrix.setup }} setup, laravel ${{ matrix.laravel }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -21,15 +21,10 @@ jobs: # Docs: <https://git.io/JvxXE>
         setup: [basic, lowest]
         laravel: [default]
         coverage: [yes]
-        php: ['7.3', '7.4', '8.0']
-        include:
-          - php: '7.3'
-            setup: basic
-            coverage: no
-            laravel: '~7.0'
+        php: ['8.0', '8.1', '8.2']
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2 # Action page: <https://github.com/shivammathur/setup-php>
@@ -39,12 +34,12 @@ jobs: # Docs: <https://git.io/JvxXE>
 
       - name: Get Composer Cache Directory # Docs: <https://git.io/JfAKn#php---composer>
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "output_dir=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies # Docs: <https://git.io/JfAKn#php---composer>
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ steps.composer-cache.outputs.output_dir }}
           key: ${{ runner.os }}-composer-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: ${{ runner.os }}-composer-
 
@@ -73,7 +68,7 @@ jobs: # Docs: <https://git.io/JvxXE>
           XDEBUG_MODE: coverage
         run: composer test-cover
 
-      - uses: codecov/codecov-action@v1 # Docs: <https://github.com/codecov/codecov-action>
+      - uses: codecov/codecov-action@v3 # Docs: <https://github.com/codecov/codecov-action>
         if: matrix.coverage == 'yes'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -83,10 +78,10 @@ jobs: # Docs: <https://git.io/JvxXE>
 
   lint-changelog:
     name: Lint changelog file
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Lint changelog file
         uses: docker://avtodev/markdown-lint:v1 # Action page: <https://github.com/avto-dev/markdown-lint>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 - Minimal require PHP version now is `8.0.2`
 - Minimal Laravel version now is `9.1.0`
 - Composer version up to `2.6.5`
-- Package `mockery/mockery` up to `^1.6`
 - Package `phpstan/phpstan` up to `^1.10`
+- Package `mockery/mockery` up to `^1.6`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Support Laravel `10.x`
+- Support PHPUnit `v10`
+
+### Changed
+
+- Minimal require PHP version now is `8.0.2`
+- Minimal Laravel version now is `9.1.0`
+- Composer version up to `2.6.5`
+- Package `mockery/mockery` up to `^1.6`
+- Package `phpstan/phpstan` up to `^1.10`
+
+### Removed
+
+- Support PHP `7.*` versions
+
 ## v2.4.0
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM php:8.0-alpine
 
 ENV COMPOSER_HOME="/tmp/composer"
 
-COPY --from=composer:2.0.7 /usr/bin/composer /usr/bin/composer
+COPY --from=composer:2.6.5 /usr/bin/composer /usr/bin/composer
 
 RUN set -x \
     && apk add --no-cache binutils git \
-    && apk add --no-cache --virtual .build-deps autoconf pkgconf make g++ gcc 1>/dev/null \
+    && apk add --no-cache --virtual .build-deps linux-headers autoconf pkgconf make g++ gcc 1>/dev/null \
     # install xdebug (for testing with code coverage), but do not enable it
-    && pecl install xdebug-3.0.0 1>/dev/null \
+    && pecl install xdebug-3.2.0 1>/dev/null \
     && apk del .build-deps \
     && mkdir --parents --mode=777 /src ${COMPOSER_HOME}/cache/repo ${COMPOSER_HOME}/cache/files \
     && ln -s /usr/bin/composer /usr/bin/c \

--- a/composer.json
+++ b/composer.json
@@ -15,18 +15,18 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^8.0.2",
         "ext-json": "*",
-        "illuminate/contracts": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/support": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/http": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "illuminate/routing": "~6.0 || ~7.0 || ~8.0 || ~9.0"
+        "illuminate/contracts": "~9.0 || ~10.0",
+        "illuminate/support": "~9.0 || ~10.0",
+        "illuminate/http": "~9.0 || ~10.0",
+        "illuminate/routing": "~9.0 || ~10.0"
     },
     "require-dev": {
-        "laravel/laravel": "~6.0 || ~7.0 || ~8.0 || ~9.0",
-        "phpunit/phpunit": "^9.3",
-        "mockery/mockery": "^1.4",
-        "phpstan/phpstan": "^0.12.36"
+        "laravel/laravel": "~9.1 || ~10.0",
+        "phpunit/phpunit": "^9.6 || ^10.4",
+        "mockery/mockery": "^1.6",
+        "phpstan/phpstan": "^1.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="./tests/bootstrap.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         forceCoversAnnotation="true"
-         processIsolation="false"
-         stopOnFailure="false">
+         forceCoversAnnotation="true">
     <testsuites>
         <testsuite name="Unit">
             <directory suffix="Test.php">./tests</directory>

--- a/src/Responses/SuccessResponse.php
+++ b/src/Responses/SuccessResponse.php
@@ -21,15 +21,15 @@ class SuccessResponse implements SuccessResponseInterface
     /**
      * Response result data.
      *
-     * @var array<mixed>|bool|float|int|object|string
+     * @var array<array-key, mixed>|bool|float|int|mixed|object|string|null
      */
     protected $result;
 
     /**
      * SuccessResponse constructor.
      *
-     * @param int|string|null                               $id     Response identifier
-     * @param array|bool|float|int|mixed|object|string|null $result Response result data
+     * @param int|string|null                                                 $id     Response identifier
+     * @param array<array-key, mixed>|bool|float|int|mixed|object|string|null $result Response result data
      *
      * @throws InvalidArgumentException If passed not valid arguments
      */

--- a/tests/Errors/InternalErrorTest.php
+++ b/tests/Errors/InternalErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\InternalError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\InternalError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\InternalError
  */
 class InternalErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Errors/InvalidParamsErrorTest.php
+++ b/tests/Errors/InvalidParamsErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\InvalidParamsError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\InvalidParamsError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\InvalidParamsError
  */
 class InvalidParamsErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Errors/InvalidRequestErrorTest.php
+++ b/tests/Errors/InvalidRequestErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\InvalidRequestError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\InvalidRequestError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\InvalidRequestError
  */
 class InvalidRequestErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Errors/MethodNotFoundErrorTest.php
+++ b/tests/Errors/MethodNotFoundErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\MethodNotFoundError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\MethodNotFoundError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\MethodNotFoundError
  */
 class MethodNotFoundErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Errors/ParseErrorTest.php
+++ b/tests/Errors/ParseErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\ParseError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\ParseError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\ParseError
  */
 class ParseErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Errors/ServerErrorTest.php
+++ b/tests/Errors/ServerErrorTest.php
@@ -7,7 +7,7 @@ namespace AvtoDev\JsonRpc\Tests\Errors;
 use AvtoDev\JsonRpc\Errors\ServerError;
 
 /**
- * @covers \AvtoDev\JsonRpc\Errors\ServerError<extended>
+ * @covers \AvtoDev\JsonRpc\Errors\ServerError
  */
 class ServerErrorTest extends AbstractErrorTestCase
 {

--- a/tests/Events/ErroredRequestDetectedEventTest.php
+++ b/tests/Events/ErroredRequestDetectedEventTest.php
@@ -11,7 +11,7 @@ use AvtoDev\JsonRpc\Errors\InvalidParamsError;
 use AvtoDev\JsonRpc\Events\ErroredRequestDetectedEvent;
 
 /**
- * @covers \AvtoDev\JsonRpc\Events\ErroredRequestDetectedEvent<extended>
+ * @covers \AvtoDev\JsonRpc\Events\ErroredRequestDetectedEvent
  */
 class ErroredRequestDetectedEventTest extends AbstractTestCase
 {

--- a/tests/Events/RequestHandledEventTest.php
+++ b/tests/Events/RequestHandledEventTest.php
@@ -10,7 +10,7 @@ use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\Events\RequestHandledEvent;
 
 /**
- * @covers \AvtoDev\JsonRpc\Events\RequestHandledEvent<extended>
+ * @covers \AvtoDev\JsonRpc\Events\RequestHandledEvent
  */
 class RequestHandledEventTest extends AbstractTestCase
 {

--- a/tests/Events/RequestHandledExceptionEventTest.php
+++ b/tests/Events/RequestHandledExceptionEventTest.php
@@ -11,7 +11,7 @@ use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\Events\RequestHandledExceptionEvent;
 
 /**
- * @covers \AvtoDev\JsonRpc\Events\RequestHandledExceptionEvent<extended>
+ * @covers \AvtoDev\JsonRpc\Events\RequestHandledExceptionEvent
  */
 class RequestHandledExceptionEventTest extends AbstractTestCase
 {

--- a/tests/Factories/RequestFactoryTest.php
+++ b/tests/Factories/RequestFactoryTest.php
@@ -25,7 +25,7 @@ use AvtoDev\JsonRpc\Responses\ResponseInterface;
 use Symfony\Component\HttpFoundation\Response as HttpResponse;
 
 /**
- * @covers \AvtoDev\JsonRpc\Factories\RequestFactory<extended>
+ * @covers \AvtoDev\JsonRpc\Factories\RequestFactory
  */
 class RequestFactoryTest extends AbstractTestCase
 {
@@ -226,7 +226,7 @@ class RequestFactoryTest extends AbstractTestCase
     }
 
     /**
-     * @return dump(123);void
+     * @return void
      */
     public function testJsonStringToRequestsStackThrowErrorOnEmptyArray(): void
     {

--- a/tests/Http/Controllers/RpcControllerTest.php
+++ b/tests/Http/Controllers/RpcControllerTest.php
@@ -15,7 +15,7 @@ use AvtoDev\JsonRpc\Http\Controllers\RpcController;
 use Illuminate\Contracts\Routing\Registrar as HttpRegistrar;
 
 /**
- * @covers \AvtoDev\JsonRpc\Http\Controllers\RpcController<extended>
+ * @covers \AvtoDev\JsonRpc\Http\Controllers\RpcController
  */
 class RpcControllerTest extends AbstractTestCase
 {
@@ -145,7 +145,7 @@ class RpcControllerTest extends AbstractTestCase
     }
 
     /**
-     * @param \Illuminate\Foundation\Testing\TestResponse|\Illuminate\Testing\TestResponse $response
+     * @param \Illuminate\Testing\TestResponse $response
      * @param string                                                                       $path
      * @param                                                                              $expect
      *

--- a/tests/MethodParameters/BaseMethodParametersTest.php
+++ b/tests/MethodParameters/BaseMethodParametersTest.php
@@ -8,7 +8,7 @@ use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\MethodParameters\BaseMethodParameters;
 
 /**
- * @covers \AvtoDev\JsonRpc\MethodParameters\BaseMethodParameters<extended>
+ * @covers \AvtoDev\JsonRpc\MethodParameters\BaseMethodParameters
  */
 class BaseMethodParametersTest extends AbstractTestCase
 {

--- a/tests/Requests/ErroredRequestTest.php
+++ b/tests/Requests/ErroredRequestTest.php
@@ -13,7 +13,7 @@ use AvtoDev\JsonRpc\Errors\InvalidRequestError;
 use AvtoDev\JsonRpc\Requests\ErroredRequestInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Requests\ErroredRequest<extended>
+ * @covers \AvtoDev\JsonRpc\Requests\ErroredRequest
  */
 class ErroredRequestTest extends AbstractTestCase
 {

--- a/tests/Requests/RequestTest.php
+++ b/tests/Requests/RequestTest.php
@@ -12,7 +12,7 @@ use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\Requests\RequestInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Requests\Request<extended>
+ * @covers \AvtoDev\JsonRpc\Requests\Request
  */
 class RequestTest extends AbstractTestCase
 {

--- a/tests/Requests/RequestsStackTest.php
+++ b/tests/Requests/RequestsStackTest.php
@@ -14,7 +14,7 @@ use AvtoDev\JsonRpc\Errors\MethodNotFoundError;
 use AvtoDev\JsonRpc\Requests\RequestsStackInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Requests\RequestsStack<extended>
+ * @covers \AvtoDev\JsonRpc\Requests\RequestsStack
  */
 class RequestsStackTest extends AbstractTestCase
 {

--- a/tests/Responses/ErrorResponseTest.php
+++ b/tests/Responses/ErrorResponseTest.php
@@ -12,7 +12,7 @@ use AvtoDev\JsonRpc\Errors\MethodNotFoundError;
 use AvtoDev\JsonRpc\Responses\ErrorResponseInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Responses\ErrorResponse<extended>
+ * @covers \AvtoDev\JsonRpc\Responses\ErrorResponse
  */
 class ErrorResponseTest extends AbstractTestCase
 {

--- a/tests/Responses/ResponsesStackTest.php
+++ b/tests/Responses/ResponsesStackTest.php
@@ -14,7 +14,7 @@ use AvtoDev\JsonRpc\Errors\MethodNotFoundError;
 use AvtoDev\JsonRpc\Responses\ResponsesStackInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Responses\ResponsesStack<extended>
+ * @covers \AvtoDev\JsonRpc\Responses\ResponsesStack
  */
 class ResponsesStackTest extends AbstractTestCase
 {

--- a/tests/Responses/SuccessResponseTest.php
+++ b/tests/Responses/SuccessResponseTest.php
@@ -11,7 +11,7 @@ use AvtoDev\JsonRpc\Responses\SuccessResponse;
 use AvtoDev\JsonRpc\Responses\SuccessResponseInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\Responses\SuccessResponse<extended>
+ * @covers \AvtoDev\JsonRpc\Responses\SuccessResponse
  */
 class SuccessResponseTest extends AbstractTestCase
 {

--- a/tests/Router/RouterTest.php
+++ b/tests/Router/RouterTest.php
@@ -11,13 +11,14 @@ use AvtoDev\JsonRpc\Router\Router;
 use AvtoDev\JsonRpc\Requests\Request;
 use AvtoDev\JsonRpc\Router\RouterInterface;
 use AvtoDev\JsonRpc\Tests\AbstractTestCase;
+use AvtoDev\JsonRpc\Tests\Stubs\RouterStub;
 use Illuminate\Contracts\Foundation\Application;
 use AvtoDev\JsonRpc\MethodParameters\BaseMethodParameters;
 use AvtoDev\JsonRpc\Requests\RequestInterface as RPCRequest;
 
 /**
  * @group  router
- * @covers \AvtoDev\JsonRpc\Router\Router<extended>
+ * @covers \AvtoDev\JsonRpc\Router\Router
  */
 class RouterTest extends AbstractTestCase
 {
@@ -53,11 +54,11 @@ class RouterTest extends AbstractTestCase
             'foo'  => function (): bool {
                 return true;
             },
-            'bar'  => static::class . '@someAction',
+            'bar'  => RouterStub::class . '@someAction',
             'baz'  => \Closure::fromCallable(function (): int {
                 return 123;
             }),
-            'blah' => [$this, 'someAction'],
+            'blah' => [new RouterStub(), 'someAction'],
         ];
 
         foreach ($actions as $name => $action) {
@@ -104,11 +105,11 @@ class RouterTest extends AbstractTestCase
             'foo'  => static function (): bool {
                 return true;
             },
-            'bar'  => static::class . '@someAction',
+            'bar'  => RouterStub::class . '@someAction',
             'baz'  => \Closure::fromCallable(function (): int {
                 return 123;
             }),
-            'blah' => [$this, 'someAction'],
+            'blah' => [new RouterStub(), 'someAction'],
         ];
 
         foreach ($actions as $name => $action) {
@@ -169,17 +170,5 @@ class RouterTest extends AbstractTestCase
         $this->expectException(InvalidArgumentException::class);
 
         $this->router->call('foo');
-    }
-
-    /**
-     * Required for actions testing.
-     *
-     * @param Application $app
-     *
-     * @return Application
-     */
-    public function someAction(Application $app): Application
-    {
-        return $app;
     }
 }

--- a/tests/RpcRouterTest.php
+++ b/tests/RpcRouterTest.php
@@ -8,7 +8,7 @@ use AvtoDev\JsonRpc\RpcRouter;
 use AvtoDev\JsonRpc\Router\RouterInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\RpcRouter<extended>
+ * @covers \AvtoDev\JsonRpc\RpcRouter
  */
 class RpcRouterTest extends AbstractTestCase
 {

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -12,7 +12,7 @@ use AvtoDev\JsonRpc\Factories\RequestFactory;
 use AvtoDev\JsonRpc\Factories\FactoryInterface;
 
 /**
- * @covers \AvtoDev\JsonRpc\ServiceProvider<extended>
+ * @covers \AvtoDev\JsonRpc\ServiceProvider
  */
 class ServiceProviderTest extends AbstractTestCase
 {

--- a/tests/Stubs/RouterStub.php
+++ b/tests/Stubs/RouterStub.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\JsonRpc\Tests\Stubs;
+
+use Illuminate\Contracts\Foundation\Application;
+
+class RouterStub
+{
+    /**
+     * Required for actions testing.
+     *
+     * @param Application $app
+     *
+     * @return Application
+     */
+    public function someAction(Application $app): Application
+    {
+        return $app;
+    }
+}

--- a/tests/Traits/ValidateNonStrictValuesTraitTest.php
+++ b/tests/Traits/ValidateNonStrictValuesTraitTest.php
@@ -10,7 +10,7 @@ use AvtoDev\JsonRpc\Tests\AbstractTestCase;
 use AvtoDev\JsonRpc\Traits\ValidateNonStrictValuesTrait;
 
 /**
- * @covers \AvtoDev\JsonRpc\Traits\ValidateNonStrictValuesTrait<extended>
+ * @covers \AvtoDev\JsonRpc\Traits\ValidateNonStrictValuesTrait
  */
 class ValidateNonStrictValuesTraitTest extends AbstractTestCase
 {


### PR DESCRIPTION
## Description

Laravel 10 and PHPUnit 10 support

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

## Changelog

### Added

- Support Laravel `10.x`
- Support PHPUnit `v10`

### Changed

- Minimal require PHP version now is `8.0.2`
- Minimal Laravel version now is `9.1.0`
- Composer version up to `2.6.5`
- Package `mockery/mockery` up to `^1.6`
- Package `phpstan/phpstan` up to `^1.10`

### Removed

- Support PHP `7.*` versions
